### PR TITLE
Remove redundant usage of `ContainsFinalizer`, prefer generic variant of `Set`

### DIFF
--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -26,7 +26,7 @@ var (
 	// MachineStateDiskErasing is the string representing an instance which is releasing (disk)
 	MachineStateDiskErasing = MachineState("Disk erasing")
 
-	// MachineStateDiskErasing is the string representing an instance which is releasing
+	// MachineStateReleasing represents an instance which is being released.
 	MachineStateReleasing = MachineState("Releasing")
 
 	// MachineStateNew is the string representing an instance which is not yet commissioned
@@ -48,32 +48,30 @@ var (
 
 	// MachineRunningStates defines the set of states in which an MaaS instance is
 	// running or going to be running soon
-	MachineRunningStates = sets.NewString(
-		string(MachineStateDeploying),
-		string(MachineStateDeployed),
+	MachineRunningStates = sets.New(
+		MachineStateDeploying,
+		MachineStateDeployed,
 	)
 
 	// MachineOperationalStates defines the set of states in which an MaaS instance is
 	// or can return to running, and supports all MaaS operations
 	MachineOperationalStates = MachineRunningStates.Union(
-		sets.NewString(
-			string(MachineStateAllocated),
-		),
+		sets.New(MachineStateAllocated),
 	)
 
 	// MachineKnownStates represents all known MaaS instance states
 	MachineKnownStates = MachineOperationalStates.Union(
-		sets.NewString(
-			string(MachineStateDiskErasing),
-			string(MachineStateReleasing),
-			string(MachineStateReady),
-			string(MachineStateNew),
+		sets.New(
+			MachineStateDiskErasing,
+			MachineStateReleasing,
+			MachineStateReady,
+			MachineStateNew,
 			//string(MachineStateTerminated),
 		),
 	)
 )
 
-// Instance describes an MAAS Machine.
+// Machine describes a MAAS Machine.
 type Machine struct {
 	ID string
 

--- a/controllers/maascluster_controller.go
+++ b/controllers/maascluster_controller.go
@@ -210,7 +210,7 @@ func IsRunning(m *infrav1beta1.MaasMachine) bool {
 	}
 
 	state := m.Status.MachineState
-	return state != nil && infrav1beta1.MachineRunningStates.Has(string(*state))
+	return state != nil && infrav1beta1.MachineRunningStates.Has(*state)
 }
 
 func getExternalMachineIP(machine *infrav1beta1.MaasMachine) string {
@@ -228,8 +228,7 @@ func (r *MaasClusterReconciler) reconcileNormal(_ context.Context, clusterScope 
 	maasCluster := clusterScope.MaasCluster
 
 	// Add finalizer first if not exist to avoid the race condition between init and delete
-	if !controllerutil.ContainsFinalizer(maasCluster, infrav1beta1.ClusterFinalizer) {
-		controllerutil.AddFinalizer(maasCluster, infrav1beta1.ClusterFinalizer)
+	if controllerutil.AddFinalizer(maasCluster, infrav1beta1.ClusterFinalizer) {
 		return ctrl.Result{}, nil
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/google/uuid v1.4.0
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.32.0
-	github.com/pkg/errors v0.9.1
 	github.com/spectrocloud/maas-client-go v0.0.1-beta1.0.20230830132549-2f7491722359
 	github.com/spf13/pflag v1.0.5
 	k8s.io/api v0.29.3
@@ -52,6 +51,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.18.0 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.45.0 // indirect

--- a/pkg/maas/dns/dns_test.go
+++ b/pkg/maas/dns/dns_test.go
@@ -11,10 +11,11 @@ import (
 	"k8s.io/klog/v2/klogr"
 	"sigs.k8s.io/cluster-api/api/v1beta1"
 
+	"github.com/spectrocloud/maas-client-go/maasclient"
+
 	infrav1beta1 "github.com/spectrocloud/cluster-api-provider-maas/api/v1beta1"
 	mockclientset "github.com/spectrocloud/cluster-api-provider-maas/pkg/maas/client/mock"
 	"github.com/spectrocloud/cluster-api-provider-maas/pkg/maas/scope"
-	"github.com/spectrocloud/maas-client-go/maasclient"
 )
 
 func TestDNS(t *testing.T) {

--- a/pkg/maas/scope/cluster.go
+++ b/pkg/maas/scope/cluster.go
@@ -18,11 +18,13 @@ package scope
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"sync"
+	"time"
+
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
-	"github.com/pkg/errors"
-	infrav1beta1 "github.com/spectrocloud/cluster-api-provider-maas/api/v1beta1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -33,8 +35,8 @@ import (
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sync"
-	"time"
+
+	infrav1beta1 "github.com/spectrocloud/cluster-api-provider-maas/api/v1beta1"
 )
 
 const (
@@ -71,7 +73,7 @@ func NewClusterScope(params ClusterScopeParams) (*ClusterScope, error) {
 
 	helper, err := patch.NewHelper(params.MaasCluster, params.Client)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to init patch helper")
+		return nil, fmt.Errorf("failed to init patch helper: %w", err)
 	}
 	return &ClusterScope{
 		Logger:              params.Logger,
@@ -156,7 +158,7 @@ func (s *ClusterScope) GetClusterMaasMachines() ([]*infrav1beta1.MaasMachine, er
 		machineList,
 		client.InNamespace(s.Cluster.Namespace),
 		client.MatchingLabels(labels)); err != nil {
-		return nil, errors.Wrap(err, "failed to list machines")
+		return nil, fmt.Errorf("failed to list machines: %w", err)
 	}
 
 	var machines []*infrav1beta1.MaasMachine

--- a/pkg/maas/scope/cluster.go
+++ b/pkg/maas/scope/cluster.go
@@ -232,7 +232,7 @@ func (s *ClusterScope) IsAPIServerOnline() (bool, error) {
 		return false, err
 	} else if !cluster.DeletionTimestamp.IsZero() {
 		s.Info("Cluster is deleting; abort APIServerOnline check", "cluster", cluster.Name)
-		return false, errors.New("Cluster is deleting; abort IsAPIServerOnline")
+		return false, errors.New("cluster is being deleted; abort IsAPIServerOnline")
 	}
 
 	remoteClient, err := s.tracker.GetClient(ctx, util.ObjectKey(s.Cluster))

--- a/pkg/maas/scope/machine.go
+++ b/pkg/maas/scope/machine.go
@@ -18,10 +18,10 @@ package scope
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
@@ -71,7 +71,7 @@ func NewMachineScope(params MachineScopeParams) (*MachineScope, error) {
 
 	helper, err := patch.NewHelper(params.MaasMachine, params.Client)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to init patch helper")
+		return nil, fmt.Errorf("failed to init patch helper: %w", err)
 	}
 	return &MachineScope{
 		Logger:         params.Logger,
@@ -248,7 +248,7 @@ func (m *MachineScope) GetRawBootstrapData() ([]byte, error) {
 	secret := &corev1.Secret{}
 	key := types.NamespacedName{Namespace: namespace, Name: *m.Machine.Spec.Bootstrap.DataSecretName}
 	if err := m.client.Get(context.TODO(), key, secret); err != nil {
-		return nil, errors.Wrapf(err, "failed to retrieve bootstrap data secret for MaasMachine %s/%s", namespace, m.Machine.Name)
+		return nil, fmt.Errorf("failed to retrieve bootstrap data secret for MaasMachine %s/%s: %w", namespace, m.Machine.Name, err)
 	}
 
 	value, ok := secret.Data["value"]

--- a/pkg/maas/scope/machine.go
+++ b/pkg/maas/scope/machine.go
@@ -224,17 +224,17 @@ func (m *MachineScope) SetMachineHostname(hostname string) {
 
 func (m *MachineScope) MachineIsRunning() bool {
 	state := m.GetMachineState()
-	return state != nil && infrav1beta1.MachineRunningStates.Has(string(*state))
+	return state != nil && infrav1beta1.MachineRunningStates.Has(*state)
 }
 
 func (m *MachineScope) MachineIsOperational() bool {
 	state := m.GetMachineState()
-	return state != nil && infrav1beta1.MachineOperationalStates.Has(string(*state))
+	return state != nil && infrav1beta1.MachineOperationalStates.Has(*state)
 }
 
 func (m *MachineScope) MachineIsInKnownState() bool {
 	state := m.GetMachineState()
-	return state != nil && infrav1beta1.MachineKnownStates.Has(string(*state))
+	return state != nil && infrav1beta1.MachineKnownStates.Has(*state)
 }
 
 // GetRawBootstrapData returns the bootstrap data from the secret in the Machine's bootstrap.dataSecretName.

--- a/pkg/maas/scope/machine.go
+++ b/pkg/maas/scope/machine.go
@@ -19,12 +19,12 @@ package scope
 import (
 	"context"
 	"fmt"
+
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
-	infrav1beta1 "github.com/spectrocloud/cluster-api-provider-maas/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	capierrors "sigs.k8s.io/cluster-api/errors"
@@ -32,6 +32,8 @@ import (
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	infrav1beta1 "github.com/spectrocloud/cluster-api-provider-maas/api/v1beta1"
 )
 
 // MachineScopeParams defines the input parameters used to create a new Scope.
@@ -139,7 +141,7 @@ func (m *MachineScope) SetNotReady() {
 
 // SetFailureMessage sets the MaasMachine status failure message.
 func (m *MachineScope) SetFailureMessage(v error) {
-	m.MaasMachine.Status.FailureMessage = pointer.StringPtr(v.Error())
+	m.MaasMachine.Status.FailureMessage = ptr.To(v.Error())
 }
 
 // SetFailureReason sets the MaasMachine status failure reason.
@@ -177,17 +179,17 @@ func (m *MachineScope) GetProviderID() string {
 // SetProviderID sets the MaasMachine providerID in spec.
 func (m *MachineScope) SetProviderID(systemID, availabilityZone string) {
 	providerID := fmt.Sprintf("maas:///%s/%s", availabilityZone, systemID)
-	m.MaasMachine.Spec.ProviderID = pointer.StringPtr(providerID)
+	m.MaasMachine.Spec.ProviderID = ptr.To(providerID)
 }
 
 // SetFailureDomain sets the MaasMachine systemID in spec.
 func (m *MachineScope) SetFailureDomain(availabilityZone string) {
-	m.MaasMachine.Spec.FailureDomain = pointer.StringPtr(availabilityZone)
+	m.MaasMachine.Spec.FailureDomain = ptr.To(availabilityZone)
 }
 
-// SetInstanceID sets the MaasMachine systemID in spec.
+// SetSystemID sets the MaasMachine systemID in spec.
 func (m *MachineScope) SetSystemID(systemID string) {
-	m.MaasMachine.Spec.SystemID = pointer.StringPtr(systemID)
+	m.MaasMachine.Spec.SystemID = ptr.To(systemID)
 }
 
 func (m *MachineScope) GetSystemID() string {
@@ -207,7 +209,7 @@ func (m *MachineScope) SetPowered(powered bool) {
 	m.MaasMachine.Status.MachinePowered = powered
 }
 
-// GetMachineHostname retrns the hostname
+// GetMachineHostname returns the hostname
 func (m *MachineScope) GetMachineHostname() string {
 	if m.MaasMachine.Status.Hostname != nil {
 		return *m.MaasMachine.Status.Hostname

--- a/test/helpers/envtest.go
+++ b/test/helpers/envtest.go
@@ -24,15 +24,14 @@ import (
 	"path"
 	"path/filepath"
 	goruntime "runtime"
-	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
-	webhookserver "sigs.k8s.io/controller-runtime/pkg/webhook"
 	"strconv"
 	"strings"
 	"time"
 
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	webhookserver "sigs.k8s.io/controller-runtime/pkg/webhook"
+
 	"github.com/onsi/ginkgo"
-	"github.com/pkg/errors"
-	"github.com/spectrocloud/cluster-api-provider-maas/test/helpers/external"
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -48,6 +47,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/spectrocloud/cluster-api-provider-maas/test/helpers/external"
 
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/log"
@@ -222,11 +223,11 @@ func buildModifiedWebhook(tag string, relativeFilePath string) (admissionv1.Muta
 	var validatingWebhook admissionv1.ValidatingWebhookConfiguration
 	data, err := os.ReadFile(filepath.Clean(filepath.Join(root, relativeFilePath)))
 	if err != nil {
-		return mutatingWebhook, validatingWebhook, errors.Wrap(err, "failed to read webhook configuration file")
+		return mutatingWebhook, validatingWebhook, fmt.Errorf("failed to read webhook configuration file: %w", err)
 	}
 	objs, err := utilyaml.ToUnstructured(data)
 	if err != nil {
-		return mutatingWebhook, validatingWebhook, errors.Wrap(err, "failed to parse yaml")
+		return mutatingWebhook, validatingWebhook, fmt.Errorf("failed to parse yaml: %w", err)
 	}
 	for i := range objs {
 		o := objs[i]

--- a/test/helpers/external/cluster.go
+++ b/test/helpers/external/cluster.go
@@ -21,7 +21,7 @@ import (
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -67,11 +67,11 @@ func generateTestClusterAPICRD(kind, pluralKind string) *apiextensionsv1.CustomR
 							Properties: map[string]apiextensionsv1.JSONSchemaProps{
 								"spec": {
 									Type:                   "object",
-									XPreserveUnknownFields: pointer.BoolPtr(true),
+									XPreserveUnknownFields: ptr.To(true),
 								},
 								"status": {
 									Type:                   "object",
-									XPreserveUnknownFields: pointer.BoolPtr(true),
+									XPreserveUnknownFields: ptr.To(true),
 								},
 							},
 						},


### PR DESCRIPTION
This changelist adds the following improvements:

1. Replace usage of deprecated package k8s.io/utils/pointer.
2. Use client.IgnoreNotFound, remove usage of pkg/errors
3. Prefer generic variant of Set
4. Remove redundant usage of ContainsFinalizer